### PR TITLE
Fix setup.py

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -55,7 +55,6 @@ setup(
     include_package_data=True,
     install_requires=[
         'django',
-        'South',
         'Pillow',
     ],
 )


### PR DESCRIPTION
Remove `south` as an explicit dependency, supported versions of django don't need south or expect it to be installed. 

One should explicity install south or they might have already installed one.