### PR TITLE
Fix forms.py for Django == 1.8

### DIFF
--- a/nicedit/forms.py
+++ b/nicedit/forms.py
@@ -7,3 +7,4 @@ class NicEditImageForm(forms.ModelForm):
 
     class Meta:
         model = NicEditImage
+        fields = '__all__'


### PR DESCRIPTION
Django 1.8+ requires either `exclude` or `fields` meta in the ModelForm.
